### PR TITLE
Fix Clear button width to match Copy button

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
                     </div>
                     <div class="col-sm-6">
                         <div class="row p-1">
-                            <button onclick="handleClear()" class="btn btn-danger btn-lg">Clear</button>
+                            <button onclick="handleClear()" class="btn btn-danger btn-lg w-100">Clear</button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Added `w-100` Bootstrap utility class to the Clear button so it fills its column the same way the Copy button does.

## Test plan
- [ ] Clear button is the same width as Copy button on desktop
- [ ] Both buttons remain proportionate on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)