### PR TITLE
Fix Clear button height to match Copy button

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
                     </div>
                     <div class="col-sm-6">
                         <div class="row p-1">
-                            <button onclick="handleClear()" class="btn btn-danger btn-lg w-100">Clear</button>
+                            <button onclick="handleClear()" class="btn btn-danger btn-lg w-100 clear-button">Clear</button>
                         </div>
                     </div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -79,11 +79,11 @@ textarea {
 }
 
 .clear-button, .copy-button, .extract-button {
-    padding: 15px 25px;
+    padding: 15px 25px !important;
     color: white !important;
     border: none;
     border-radius: 5px !important;
-    font-size: 16px;
+    font-size: 16px !important;
     cursor: pointer;
     transition: background-color 0.3s;
 }


### PR DESCRIPTION
## Summary
- Added `clear-button` class to the Clear button so the shared CSS padding (`15px 25px`) and font-size (`16px`) apply to it
- Added `!important` to `padding` and `font-size` in the shared `.clear-button, .copy-button, .extract-button` rule so Bootstrap's `btn-lg` (which sets a larger 20px font size) cannot override them

Without this, the Clear button was taller than Copy because it was getting Bootstrap's default `btn-lg` font size instead of the custom 16px.

## Test plan
- [ ] Clear and Copy buttons are the same height
- [ ] Extract Keys button height is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)